### PR TITLE
Fixed header installation in oshw

### DIFF
--- a/oshw/CMakeLists.txt
+++ b/oshw/CMakeLists.txt
@@ -11,5 +11,5 @@ install(TARGETS oshw
   LIBRARY DESTINATION lib )
 
 
-install(FILES oshw.h nicdrv.h
+install(FILES linux/oshw.h linux/nicdrv.h
         DESTINATION include/soem )


### PR DESCRIPTION
The oshw headers are located in the `linux/` subdirectory. The install rule without the directory prefix fails.
