### PR TITLE
remove -Werror flag for linux

### DIFF
--- a/SOEM/CMakeLists.txt
+++ b/SOEM/CMakeLists.txt
@@ -24,7 +24,7 @@ if(WIN32)
   set(OS_LIBS wpcap.lib Packet.lib Ws2_32.lib Winmm.lib)
 elseif(UNIX AND NOT APPLE)
   set(OS "linux")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
   set(OS_LIBS pthread rt)
 elseif(APPLE)
   # This must come *before* linux or MacOSX will identify as Unix.


### PR DESCRIPTION
This is to fix a problem with the release of the ROS Noetic package in Ubuntu focal. There is a new warning introduced that gets treated as an error. See ros/rosdistro#25540 for details.

This is now fixed with this PR, but needs to be reverted at the next sync.